### PR TITLE
extend firebase typings with Promises

### DIFF
--- a/lib/ngWhen.ts
+++ b/lib/ngWhen.ts
@@ -4,7 +4,7 @@
 // November 2015
 
 import {Directive} from 'angular2/src/core/metadata';
-import {DoCheck, ChangeDetectorRef} from 'angular2/core';
+import {DoCheck, ChangeDetectorRef, EmbeddedViewRef} from 'angular2/core';
 import {ViewContainerRef, TemplateRef, ViewRef} from 'angular2/src/core/linker';
 import {isPresent, isBlank} from 'angular2/src/facade/lang';
 
@@ -65,7 +65,7 @@ export class NgWhen {
   /** @internal */
   private _prevCondition: any = null;
   // TODO remove _prevCondition, the viewRef is enough.
-  private _viewRef: ViewRef = null;
+  private _viewRef: EmbeddedViewRef = null;
 
   constructor(private _viewContainer: ViewContainerRef, private _templateRef: TemplateRef,
               private _cdr: ChangeDetectorRef) { }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   "author": "Kyle Cordes <kyle.cordes@oasisdigital.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "angular2": "^2.0.0-beta.0",
-    "rxjs": "^5.0.0-beta.0",
-    "zone.js": "^0.5.10"
+    "angular2": "^2.0.0-beta.3",
+    "rxjs": "5.0.0-beta.0",
+    "zone.js": "0.5.11"
   },
   "devDependencies": {
     "typescript": "~1.7.5"

--- a/typings/firebase/firebase.d.ts
+++ b/typings/firebase/firebase.d.ts
@@ -69,30 +69,30 @@ interface FirebaseOnDisconnect {
 	 * (due to closing the browser, navigating to a new page, or network issues).
 	 */
 	set(value: any, onComplete: (error: any) => void): void;
-	set(value: any): Promise;
+	set(value: any): Promise<any>;
 	/**
 	 * Ensures the data at this location is set to the specified value and priority when the client is disconnected
 	 * (due to closing the browser, navigating to a new page, or network issues).
 	 */
 	setWithPriority(value: any, priority: string|number, onComplete?: (error: any) => void): void;
-	setWithPriority(value: any, priority: string|number): Promise;
+	setWithPriority(value: any, priority: string|number): Promise<any>;
 	/**
 	 * Writes the enumerated children at this Firebase location when the client is disconnected
 	 * (due to closing the browser, navigating to a new page, or network issues).
 	 */
 	update(value: Object, onComplete?: (error: any) => void): void;
-	update(value: Object): Promise;
+	update(value: Object): Promise<any>;
 	/**
 	 * Ensures the data at this location is deleted when the client is disconnected
 	 * (due to closing the browser, navigating to a new page, or network issues).
 	 */
 	remove(onComplete?: (error: any) => void): void;
-	remove(): Promise;
+	remove(): Promise<any>;
 	/**
 	 * Cancels all previously queued onDisconnect() set or update events for this location and all children.
 	 */
 	cancel(onComplete?: (error: any) => void): void;
-	cancel(): Promise;
+	cancel(): Promise<any>;
 }
 
 interface FirebaseQuery {
@@ -237,32 +237,32 @@ interface Firebase extends FirebaseQuery {
 	 * Writes data to this Firebase location.
 	 */
 	set(value: any, onComplete: (error: any) => void): void;
-	set(value: any): Promise;
+	set(value: any): Promise<any>;
 	/**
 	 * Writes the enumerated children to this Firebase location.
 	 */
 	update(value: Object, onComplete?: (error: any) => void): void;
-	update(value: Object): Promise;
+	update(value: Object): Promise<any>;
 	/**
 	 * Removes the data at this Firebase location.
 	 */
 	remove(onComplete?: (error: any) => void): void;
-	remove(): Promise;
+	remove(): Promise<any>;
 	/**
 	 * Generates a new child location using a unique name and returns a Firebase reference to it.
 	 * @returns {Firebase} A Firebase reference for the generated location.
 	 */
-	push(value?: any, onComplete?: (error: any) => void): Firebase|Promise;
+	push(value?: any, onComplete?: (error: any) => void): Firebase|Promise<any>;
 	/**
 	 * Writes data to this Firebase location. Like set() but also specifies the priority for that data.
 	 */
 	setWithPriority(value: any, priority: string|number, onComplete?: (error: any) => void): void;
-	setWithPriority(value: any, priority: string|number): Promise;
+	setWithPriority(value: any, priority: string|number): Promise<any>;
 	/**
 	 * Sets a priority for the data at this Firebase location.
 	 */
 	setPriority(priority: string|number, onComplete?: (error: any) => void): void;
-	setPriority(priority: string|number): Promise;
+	setPriority(priority: string|number): Promise<any>;
 	/**
 	 * Atomically modifies the data at this location.
 	 */

--- a/typings/firebase/firebase.d.ts
+++ b/typings/firebase/firebase.d.ts
@@ -68,27 +68,31 @@ interface FirebaseOnDisconnect {
 	 * Ensures the data at this location is set to the specified value when the client is disconnected
 	 * (due to closing the browser, navigating to a new page, or network issues).
 	 */
-	set(value: any, onComplete?: (error: any) => void): void;
+	set(value: any, onComplete: (error: any) => void): void;
+	set(value: any): Promise;
 	/**
 	 * Ensures the data at this location is set to the specified value and priority when the client is disconnected
 	 * (due to closing the browser, navigating to a new page, or network issues).
 	 */
-	setWithPriority(value: any, priority: string, onComplete?: (error: any) => void): void;
-	setWithPriority(value: any, priority: number, onComplete?: (error: any) => void): void;
+	setWithPriority(value: any, priority: string|number, onComplete?: (error: any) => void): void;
+	setWithPriority(value: any, priority: string|number): Promise;
 	/**
 	 * Writes the enumerated children at this Firebase location when the client is disconnected
 	 * (due to closing the browser, navigating to a new page, or network issues).
 	 */
 	update(value: Object, onComplete?: (error: any) => void): void;
+	update(value: Object): Promise;
 	/**
 	 * Ensures the data at this location is deleted when the client is disconnected
 	 * (due to closing the browser, navigating to a new page, or network issues).
 	 */
 	remove(onComplete?: (error: any) => void): void;
+	remove(): Promise;
 	/**
 	 * Cancels all previously queued onDisconnect() set or update events for this location and all children.
 	 */
 	cancel(onComplete?: (error: any) => void): void;
+	cancel(): Promise;
 }
 
 interface FirebaseQuery {

--- a/typings/firebase/firebase.d.ts
+++ b/typings/firebase/firebase.d.ts
@@ -236,30 +236,33 @@ interface Firebase extends FirebaseQuery {
 	/**
 	 * Writes data to this Firebase location.
 	 */
-	set(value: any, onComplete?: (error: any) => void): void;
+	set(value: any, onComplete: (error: any) => void): void;
+	set(value: any): Promise;
 	/**
 	 * Writes the enumerated children to this Firebase location.
 	 */
 	update(value: Object, onComplete?: (error: any) => void): void;
+	update(value: Object): Promise;
 	/**
 	 * Removes the data at this Firebase location.
 	 */
 	remove(onComplete?: (error: any) => void): void;
+	remove(): Promise;
 	/**
 	 * Generates a new child location using a unique name and returns a Firebase reference to it.
 	 * @returns {Firebase} A Firebase reference for the generated location.
 	 */
-	push(value?: any, onComplete?: (error: any) => void): Firebase;
+	push(value?: any, onComplete?: (error: any) => void): Firebase|Promise;
 	/**
 	 * Writes data to this Firebase location. Like set() but also specifies the priority for that data.
 	 */
-	setWithPriority(value: any, priority: string, onComplete?: (error: any) => void): void;
-	setWithPriority(value: any, priority: number, onComplete?: (error: any) => void): void;
+	setWithPriority(value: any, priority: string|number, onComplete?: (error: any) => void): void;
+	setWithPriority(value: any, priority: string|number): Promise;
 	/**
 	 * Sets a priority for the data at this Firebase location.
 	 */
-	setPriority(priority: string, onComplete?: (error: any) => void): void;
-	setPriority(priority: number, onComplete?: (error: any) => void): void;
+	setPriority(priority: string|number, onComplete?: (error: any) => void): void;
+	setPriority(priority: string|number): Promise;
 	/**
 	 * Atomically modifies the data at this location.
 	 */


### PR DESCRIPTION
main goal of these changes is to allow using Promises returned by firebase framework i.e.

```
new Firebase("https://some-app.firebaseio.com/")
  .child('data')
  .push({prop: 'value'})
  .then((result) => doSomething(result))
```
