### PR TITLE
Updating package to angular2@^2.0.0-beta.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
   "author": "Kyle Cordes <kyle.cordes@oasisdigital.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "angular2": "2.0.0-beta.6",
-    "rxjs": "5.0.0-beta.0",
-    "zone.js": "0.5.14"
+    "reflect-metadata": "^0.1.2",
+    "rxjs": "^5.0.0-beta.2",
+    "zone.js": "^0.6.4",
+    "es6-promise": "^3.1.2",
+    "es6-shim": "^0.35.0",
+    "angular2": "^2.0.0-beta.11"
   },
   "devDependencies": {
     "typescript": "1.7.5"


### PR DESCRIPTION
Updated the package to work with angular2@^2.0.0-beta.11.
By some reason npm install isn't installing reflect-metadata@0.1.2 and rxjs@5.0.0-beta.2, so the build fails on the first try. They have to be manually installed for the build to work

```
npm install
npm install reflect-metadata@0.1.2 rxjs@5.0.0-beta.2
tsc --target es6
```
